### PR TITLE
Update extract.rb - outdated regex

### DIFF
--- a/extract.rb
+++ b/extract.rb
@@ -8,7 +8,7 @@ lists = []
 #To refresh, curl:
 #https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet
 File.open('XSS_Filter_Evasion_Cheat_Sheet', 'r:UTF-8', ).each_line do |line|
-  if /<pre>(?<xss>.*)/ =~ line
+  if /<pre(?:( class="(.*)"))>(?<xss>.*)/ =~ line
     vuln = {exploit: CGI.unescapeHTML(xss)}
     lists << vuln
   end


### PR DESCRIPTION
The regex is outdated. The OWASP XSS Filter Evasion Cheat Sheet now includes a class within the pre tag, I have altered the script to suit both the `<pre>` and `<pre class="something here">` versions